### PR TITLE
#19 Add rollbar error management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "rack-cors"
 
 # Analytics
 gem "posthog-ruby", require: false
+gem "rollbar"
 
 # Asset pipeline
 gem "propshaft", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
+    rollbar (3.7.0)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -394,6 +395,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 8.0.2)
   redis (~> 5.4)
+  rollbar
   rspec-rails
   rubocop-rails-omakase
   rubocop-rspec (~> 3.6)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ This Rails 8 application renders the React SPA directly from Rails. The React so
 ## Building assets
 Run `npm run build` to output compiled assets to `app/assets/builds`. The Rails asset pipeline will serve them in production when `RAILS_SERVE_STATIC_FILES=1` is set.
 
+## Monitoring
+The app integrates Rollbar on both the Rails backend and the React client. The frontend reads its access
+token from the backend via `GET /rollbar`, so it should only be configured on the server side.
+
+Configure the following environment variables or Rails credentials:
+
+- `ROLLBAR_SERVER_ACCESS_TOKEN`: Server-side Rollbar access token for Rails error reporting.
+- `ROLLBAR_CLIENT_ACCESS_TOKEN`: Client-side Rollbar access token returned to the React app.
+- `ROLLBAR_ENVIRONMENT`: Rollbar environment name (defaults to `Rails.env`).
+- `ROLLBAR_CODE_VERSION`: Optional release identifier for source maps and deployments.
+
 ## Tests
 - Run all Rails tests: `bin/rails test`
 - Lint Ruby files: `bin/rubocop -f github`

--- a/app/assets/javascript/entrypoints/application.jsx
+++ b/app/assets/javascript/entrypoints/application.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { ErrorBoundary, Provider as RollbarProvider } from "@rollbar/react";
 import App from "../App";
 import "../App.css";
 import "../lib/posthog";
+import { initializeRollbar } from "../lib/rollbar";
 import "../../javascript/App.css";
 import "../../javascript/index.css";
 document.addEventListener("DOMContentLoaded", () => {
@@ -11,11 +13,30 @@ document.addEventListener("DOMContentLoaded", () => {
   if (rootElement) {
     const root = ReactDOM.createRoot(rootElement);
 
-    root.render(
+    const app = (
       <React.StrictMode>
         <App />
       </React.StrictMode>
     );
+
+    const renderApp = (rollbarInstance) => {
+      const appWithRollbar = rollbarInstance ? (
+        <RollbarProvider instance={rollbarInstance}>
+          <ErrorBoundary>{app}</ErrorBoundary>
+        </RollbarProvider>
+      ) : (
+        app
+      );
+
+      root.render(appWithRollbar);
+    };
+
+    initializeRollbar()
+      .then(renderApp)
+      .catch((error) => {
+        console.warn("Rollbar failed to initialize", error);
+        renderApp(null);
+      });
   } else {
     console.error("Could not find #root element to mount React app");
   }

--- a/app/assets/javascript/lib/rollbar.js
+++ b/app/assets/javascript/lib/rollbar.js
@@ -1,0 +1,38 @@
+import Rollbar from "rollbar";
+import { baseURL } from "./api";
+
+async function fetchRollbarConfig() {
+  const response = await fetch(`${baseURL}/rollbar`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return response.json();
+}
+
+export async function initializeRollbar() {
+  const config = await fetchRollbarConfig();
+
+  if (!config?.access_token) {
+    return null;
+  }
+
+  return new Rollbar({
+    accessToken: config.access_token,
+    captureUncaught: true,
+    captureUnhandledRejections: true,
+    environment: config.environment,
+    payload: {
+      client: {
+        javascript: {
+          source_map_enabled: true,
+          code_version: config.code_version,
+        },
+      },
+    },
+  });
+}

--- a/app/controllers/rollbar_controller.rb
+++ b/app/controllers/rollbar_controller.rb
@@ -1,0 +1,29 @@
+class RollbarController < ActionController::API
+  def show
+    token = rollbar_client_access_token
+
+    render json: {
+      enabled: token.present?,
+      access_token: token,
+      environment: rollbar_environment,
+      code_version: rollbar_code_version
+    }.compact
+  end
+
+  private
+    def rollbar_client_access_token
+      Rails.application.credentials.dig(:rollbar, :client_access_token) ||
+        ENV["ROLLBAR_CLIENT_ACCESS_TOKEN"]
+    end
+
+    def rollbar_environment
+      Rails.application.credentials.dig(:rollbar, :environment) ||
+        ENV["ROLLBAR_ENVIRONMENT"] ||
+        Rails.env
+    end
+
+    def rollbar_code_version
+      Rails.application.credentials.dig(:rollbar, :code_version) ||
+        ENV["ROLLBAR_CODE_VERSION"]
+    end
+end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,10 @@
+Rollbar.configure do |config|
+  config.access_token = Rails.application.credentials.dig(:rollbar, :server_access_token) ||
+    ENV["ROLLBAR_SERVER_ACCESS_TOKEN"]
+
+  config.environment = Rails.application.credentials.dig(:rollbar, :environment) ||
+    ENV["ROLLBAR_ENVIRONMENT"] ||
+    Rails.env
+
+  config.enabled = config.access_token.present?
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   defaults format: :json do
     post "sign_in", to: "sessions#create"
     post "sign_up", to: "registrations#create"
+    get "rollbar", to: "rollbar#show"
     resources :sessions, only: [ :index, :show, :destroy ]
     resource  :password, only: [ :edit, :update ]
 


### PR DESCRIPTION
## This PR includes:
- Added the React Rollbar bootstrap to fetch configuration from the Rails backend and only initialize the provider/error boundary when a client token is returned, keeping the token out of frontend build-time envs.
- Added a backend Rollbar config endpoint plus server-side Rollbar initializer and route wiring for API delivery of the client token.
- Documented the server-side Rollbar configuration variables and added the Rollbar gem dependency.