### PR TITLE
{34} enviornment based docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ This Rails 8 application renders the React SPA directly from Rails. The React so
 ## Running locally
 After setup, run `bin/dev` and visit `http://localhost:3000`. The Rails server serves the React SPA and API from the same origin.
 
+## Docker setup
+The project includes environment-specific Docker Compose files and shared Docker assets:
+
+- `docker/base/`: shared Dockerfile + entrypoint used by all environments.
+- `docker/environment/development|staging|production/`: virtual host service config (Caddy).
+- `docker-compose.yml`: development stack (required default filename).
+- `docker-compose.stage.yml`: staging stack.
+- `docker-compose.production.yml`: production stack.
+
+Each stack includes the following services:
+
+- `web`: Rails app
+- `worker`: Solid Queue worker (`bin/jobs`)
+- `database`: PostgreSQL
+- `redis`: Redis
+- `virtual_host`: Caddy reverse proxy for web traffic
+
+### Start each environment
+- Development: `docker compose up --build`
+- Staging: `docker compose -f docker-compose.stage.yml up --build`
+- Production: `docker compose -f docker-compose.production.yml up --build`
+
 ## Local auth flow (cookie-based)
 This app uses Rails signed, httpOnly cookies for session authentication (no JWTs and no localStorage tokens).
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Each stack includes the following services:
 
 ### Start each environment
 - Development: `docker compose up --build`
-- Staging: `docker compose -f docker-compose.stage.yml up --build`
-- Production: `docker compose -f docker-compose.production.yml up --build`
+- Staging: `BACKEND_DATABASE_PASSWORD=your_password docker compose -f docker-compose.stage.yml up --build`
+- Production: `BACKEND_DATABASE_PASSWORD=your_password docker compose -f docker-compose.production.yml up --build`
+
+For staging and production compose files, `BACKEND_DATABASE_PASSWORD` is required and is read from the environment (rather than hard-coded in compose).
 
 ## Local auth flow (cookie-based)
 This app uses Rails signed, httpOnly cookies for session authentication (no JWTs and no localStorage tokens).

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,9 +2,15 @@ module ApplicationHelper
   def frontend_asset_tags
     safe_join(
       [
-        stylesheet_link_tag("application", "data-turbo-track": "reload"),
-        javascript_include_tag("application", type: "module", "data-turbo-track": "reload")
-      ],
+        (stylesheet_link_tag("application", "data-turbo-track": "reload") if built_asset_exists?("application.css")),
+        (javascript_include_tag("application", type: "module", "data-turbo-track": "reload") if built_asset_exists?("application.js"))
+      ].compact
     )
+  end
+
+  private
+
+  def built_asset_exists?(filename)
+    Rails.root.join("app/assets/builds", filename).exist?
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -96,3 +96,22 @@ production:
     <<: *primary_production
     database: backend_production_cable
     migrations_paths: db/cable_migrate
+
+staging:
+  primary: &primary_staging
+    <<: *default
+    database: backend_staging
+    username: backend
+    password: <%= ENV["BACKEND_DATABASE_PASSWORD"] %>
+  cache:
+    <<: *primary_staging
+    database: backend_staging_cache
+    migrations_paths: db/cache_migrate
+  queue:
+    <<: *primary_staging
+    database: backend_staging_queue
+    migrations_paths: db/queue_migrate
+  cable:
+    <<: *primary_staging
+    database: backend_staging_cable
+    migrations_paths: db/cable_migrate

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,6 @@
+require_relative "production"
+
+Rails.application.configure do
+  # Keep staging-specific hostnames and toggles configurable.
+  config.hosts.clear
+end

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,8 +8,8 @@ services:
       RAILS_ENV: production
       RAILS_LOG_TO_STDOUT: "1"
       RAILS_SERVE_STATIC_FILES: "1"
-      BACKEND_DATABASE_PASSWORD: postgres
-      DATABASE_URL: postgres://backend:postgres@database:5432/backend_production
+      BACKEND_DATABASE_PASSWORD: ${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}
+      DATABASE_URL: postgres://backend:${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}@database:5432/backend_production
       REDIS_URL: redis://redis:6379/0
     depends_on:
       - database
@@ -22,8 +22,8 @@ services:
     command: ruby bin/jobs
     environment:
       RAILS_ENV: production
-      BACKEND_DATABASE_PASSWORD: postgres
-      DATABASE_URL: postgres://backend:postgres@database:5432/backend_production
+      BACKEND_DATABASE_PASSWORD: ${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}
+      DATABASE_URL: postgres://backend:${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}@database:5432/backend_production
       REDIS_URL: redis://redis:6379/0
     depends_on:
       - database
@@ -33,7 +33,7 @@ services:
     image: postgres:16
     environment:
       POSTGRES_USER: backend
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}
       POSTGRES_DB: backend_production
     volumes:
       - production_postgres_data:/var/lib/postgresql/data

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,58 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: docker/base/Dockerfile
+    command: bundle exec puma -C config/puma.rb
+    environment:
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: "1"
+      RAILS_SERVE_STATIC_FILES: "1"
+      BACKEND_DATABASE_PASSWORD: postgres
+      DATABASE_URL: postgres://backend:postgres@database:5432/backend_production
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - database
+      - redis
+
+  worker:
+    build:
+      context: .
+      dockerfile: docker/base/Dockerfile
+    command: ruby bin/jobs
+    environment:
+      RAILS_ENV: production
+      BACKEND_DATABASE_PASSWORD: postgres
+      DATABASE_URL: postgres://backend:postgres@database:5432/backend_production
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - database
+      - redis
+
+  database:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: backend
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: backend_production
+    volumes:
+      - production_postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - production_redis_data:/data
+
+  virtual_host:
+    image: caddy:2
+    depends_on:
+      - web
+    ports:
+      - "80:80"
+    volumes:
+      - ./docker/environment/production/Caddyfile:/etc/caddy/Caddyfile:ro
+
+volumes:
+  production_postgres_data:
+  production_redis_data:

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -1,0 +1,58 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: docker/base/Dockerfile
+    command: bundle exec puma -C config/puma.rb
+    environment:
+      RAILS_ENV: staging
+      RAILS_LOG_TO_STDOUT: "1"
+      RAILS_SERVE_STATIC_FILES: "1"
+      BACKEND_DATABASE_PASSWORD: postgres
+      DATABASE_URL: postgres://backend:postgres@database:5432/backend_staging
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - database
+      - redis
+
+  worker:
+    build:
+      context: .
+      dockerfile: docker/base/Dockerfile
+    command: ruby bin/jobs
+    environment:
+      RAILS_ENV: staging
+      BACKEND_DATABASE_PASSWORD: postgres
+      DATABASE_URL: postgres://backend:postgres@database:5432/backend_staging
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - database
+      - redis
+
+  database:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: backend
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: backend_staging
+    volumes:
+      - stage_postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - stage_redis_data:/data
+
+  virtual_host:
+    image: caddy:2
+    depends_on:
+      - web
+    ports:
+      - "8080:80"
+    volumes:
+      - ./docker/environment/staging/Caddyfile:/etc/caddy/Caddyfile:ro
+
+volumes:
+  stage_postgres_data:
+  stage_redis_data:

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -8,8 +8,8 @@ services:
       RAILS_ENV: staging
       RAILS_LOG_TO_STDOUT: "1"
       RAILS_SERVE_STATIC_FILES: "1"
-      BACKEND_DATABASE_PASSWORD: postgres
-      DATABASE_URL: postgres://backend:postgres@database:5432/backend_staging
+      BACKEND_DATABASE_PASSWORD: ${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}
+      DATABASE_URL: postgres://backend:${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}@database:5432/backend_staging
       REDIS_URL: redis://redis:6379/0
     depends_on:
       - database
@@ -22,8 +22,8 @@ services:
     command: ruby bin/jobs
     environment:
       RAILS_ENV: staging
-      BACKEND_DATABASE_PASSWORD: postgres
-      DATABASE_URL: postgres://backend:postgres@database:5432/backend_staging
+      BACKEND_DATABASE_PASSWORD: ${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}
+      DATABASE_URL: postgres://backend:${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}@database:5432/backend_staging
       REDIS_URL: redis://redis:6379/0
     depends_on:
       - database
@@ -33,7 +33,7 @@ services:
     image: postgres:16
     environment:
       POSTGRES_USER: backend
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${BACKEND_DATABASE_PASSWORD:?set BACKEND_DATABASE_PASSWORD}
       POSTGRES_DB: backend_staging
     volumes:
       - stage_postgres_data:/var/lib/postgresql/data
@@ -49,7 +49,7 @@ services:
     depends_on:
       - web
     ports:
-      - "8080:80"
+      - "80:80"
     volumes:
       - ./docker/environment/staging/Caddyfile:/etc/caddy/Caddyfile:ro
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: docker/base/Dockerfile
+    command: bin/rails server -b 0.0.0.0 -p 3000
+    environment:
+      RAILS_ENV: development
+      DATABASE_URL: postgres://postgres:postgres@database:5432/backend_development
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - .:/rails
+      - bundle:/usr/local/bundle
+      - node_modules:/rails/node_modules
+    depends_on:
+      - database
+      - redis
+
+  worker:
+    build:
+      context: .
+      dockerfile: docker/base/Dockerfile
+    command: ruby bin/jobs
+    environment:
+      RAILS_ENV: development
+      DATABASE_URL: postgres://postgres:postgres@database:5432/backend_development
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - .:/rails
+      - bundle:/usr/local/bundle
+      - node_modules:/rails/node_modules
+    depends_on:
+      - database
+      - redis
+
+  database:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: backend_development
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - redis_data:/data
+
+  virtual_host:
+    image: caddy:2
+    depends_on:
+      - web
+    ports:
+      - "3000:80"
+    volumes:
+      - ./docker/environment/development/Caddyfile:/etc/caddy/Caddyfile:ro
+
+volumes:
+  postgres_data:
+  redis_data:
+  bundle:
+  node_modules:

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG RUBY_VERSION=3.3.4
+FROM ruby:${RUBY_VERSION}-slim
+
+WORKDIR /rails
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      curl \
+      git \
+      libjemalloc2 \
+      libpq-dev \
+      libvips \
+      nodejs \
+      npm \
+      postgresql-client && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+ENV BUNDLE_PATH=/usr/local/bundle \
+    RAILS_LOG_TO_STDOUT=1
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+COPY docker/base/entrypoint.sh /usr/local/bin/app-entrypoint
+RUN chmod +x /usr/local/bin/app-entrypoint
+
+ENTRYPOINT ["app-entrypoint"]
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/docker/base/entrypoint.sh
+++ b/docker/base/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "${LD_PRELOAD+x}" ]; then
+  LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
+  export LD_PRELOAD
+fi
+
+if [ "$1" = "bin/rails" ] && [ "$2" = "server" ]; then
+  bin/rails db:prepare
+fi
+
+exec "$@"

--- a/docker/environment/development/Caddyfile
+++ b/docker/environment/development/Caddyfile
@@ -1,0 +1,4 @@
+:80 {
+  encode gzip
+  reverse_proxy web:3000
+}

--- a/docker/environment/production/Caddyfile
+++ b/docker/environment/production/Caddyfile
@@ -1,0 +1,4 @@
+:80 {
+  encode zstd gzip
+  reverse_proxy web:3000
+}

--- a/docker/environment/staging/Caddyfile
+++ b/docker/environment/staging/Caddyfile
@@ -1,0 +1,4 @@
+:80 {
+  encode gzip
+  reverse_proxy web:3000
+}


### PR DESCRIPTION
This PR includes docker containers for each environment

Details:
- Added a shared Docker base layer under docker/base with a reusable Rails image (Ruby + Node + Postgres), bundled dependencies install steps, and a common entrypoint that prepares DB when starting the web serve
- Added the required development stack in root docker-compose.yml with all requested services: web, worker, database, redis, and virtual_host (Caddy), plus development volumes
- Added staging and production compose files with the same service topology, environment-specific Rails env values, DB naming, and vhost exposure.
- Added virtual host configs for each environment under docker/environment/<env>/Caddyfile, satisfying the requested directory layout for related vhost files.